### PR TITLE
Add package-lock and node_modules to ignore

### DIFF
--- a/parser/vars.go
+++ b/parser/vars.go
@@ -5,7 +5,7 @@ var (
 	MaxFileLength     = 10000
 	ToSendDirName     = "sendGPT"
 	MashFileName      = "mash.gpt"
-	IgnoreFiles       = []string{MashFileName}
+	IgnoreFiles       = []string{MashFileName, "package-lock.json"}
 	IgnoreExt         = []string{".png", ".jpg", ".gpt"}
-	IgnoreDirectories = []string{".git", ToSendDirName}
+	IgnoreDirectories = []string{".git", ToSendDirName, "node_modules"}
 )


### PR DESCRIPTION
Added these, but I should add some sort of user configuration for custom ignore/un-ignore directories.  These could be through CLI arguments which a user could simply alias:

```shell
alias code-to-gpt="code-to-gpt --ignore[-dir] dist --ignore[-dir] bin --keep[-dir] node_modules --keep[-file] package-lock.json
```

`--keep|--ignore` arguments would be blanket with optional specificity of `-dir|-file`